### PR TITLE
Use `eos-vm-jit` as runtime instead of `eos-vm`

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -7,7 +7,7 @@ signature-provider = EOS5uHeBsURAT6bBXNtvwKtWaiDSDJSdSmc96rHVws5M1qqVCkAm6=KEY:5
 http-server-address = 0.0.0.0:8888
 p2p-listen-endpoint = 0.0.0.0:9876
 
-wasm-runtime = eos-vm
+wasm-runtime = eos-vm-jit
 eos-vm-oc-enable = all
 
 chain-state-db-size-mb = 65536


### PR DESCRIPTION
This should make the execution more efficient and avoid issues when executing expensive transactions (e.g. proof verification on SNARKtor).